### PR TITLE
Fix 'dinamically' to 'dynamically'

### DIFF
--- a/retwddit.js
+++ b/retwddit.js
@@ -11,10 +11,10 @@ function main() {
         addRedditButton(tweet);
     }
 
-    $(document).on("DOMNodeInserted", ".tweet", addDinamicallyRedditButton);
+    $(document).on("DOMNodeInserted", ".tweet", addDynamicallyRedditButton);
 }
 
-function addDinamicallyRedditButton() {
+function addDynamicallyRedditButton() {
     var tweet = $(this).get(0);
     addRedditButton(tweet);
 }


### PR DESCRIPTION
Hey - great extension!

"addDinamicallyRedditButton" should probably be spelled "addDynamicallyRedditButton". This PR fixes that typo.
